### PR TITLE
Update flysystem-sharepoint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
         }
     ],
     "require": {
-        "php": "^7.0",
-        "league/flysystem": "2.1.1"
+        "php": "^7.3 || ^8.0",
+        "league/flysystem": "^1.1",
         "delaneymethod/sharepoint-api": "^2.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^8.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,7 +22,7 @@
     <logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage" showUncoveredFiles="true"/>
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>

--- a/tests/SharepointAdapterTest.php
+++ b/tests/SharepointAdapterTest.php
@@ -18,7 +18,7 @@ class SharepointAdapterTest extends TestCase
 	/** @var \DelaneyMethod\FlysystemSharepoint\SharepointAdapter */
 	protected $sharepointAdapter;
 
-	public function setUp()
+	public function setUp(): void
 	{
 		$this->client = $this->prophesize(Client::class);
 


### PR DESCRIPTION
Modernize flysystem-sharepoint plugin to work with supported versions of PHP, PHPUnit and sharepoint-api. Update test case `setUp` signature.

* Leave Flysystem at 1.1, suitable for Laravel 8
* Upgrade to PHPUnit 8.5, and PHP to 7.3 or 8.0
* Apply new method signature
